### PR TITLE
MELOSYS-3266 - Revert fritekst videresend soknad

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "^4.17.15",
     "log4js": "^5.1.0",
     "melosys-kodeverk": "^5.12.1",
-    "melosys-schema": "^1.33.1",
+    "melosys-schema": "^1.33.4",
     "moment": "^2.24.0",
     "node-cache": "^4.2.1",
     "node-emoji": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "^4.17.15",
     "log4js": "^5.1.0",
     "melosys-kodeverk": "^5.12.1",
-    "melosys-schema": "^1.33.3",
+    "melosys-schema": "^1.33.1",
     "moment": "^2.24.0",
     "node-cache": "^4.2.1",
     "node-emoji": "^1.10.0",

--- a/scripts/katalog.js
+++ b/scripts/katalog.js
@@ -281,8 +281,8 @@ const pathnameMap = {
     },
   },
   'fagsaker-henleggvideresend': {
-    moduleName:'fagsaker-henleggvideresend',
-    post: {
+    moduleName:'fagsaker-videresend',
+    put: {
       pathname: '/fagsaker/:saksnummer/henlegg-videresend',
       params: { saksnummer: 4 },
     },

--- a/scripts/katalog.js
+++ b/scripts/katalog.js
@@ -189,7 +189,7 @@ const pathnameMap = {
     moduleName: 'journalforing',
     get: {
       pathname: '/journalforing/:journalpostID',
-      params: { journalpostID: 4 },
+      params: { journalpostID: 'DOK_3789' },
     },
   },
   'journalforing-opprett': {

--- a/scripts/mock_api_server.js
+++ b/scripts/mock_api_server.js
@@ -132,7 +132,7 @@ router.get('/fagsaker/sok/', Fagsaker.sok.hent);
 router.get('/fagsaker/:saksnummer', Fagsaker.fagsak.hent);
 router.post('/fagsaker/:saksnummer/henlegg', Fagsaker.fagsak.henlegg.send);
 router.put('/fagsaker/:saksnummer/avsluttsaksombortfalt', Fagsaker.fagsak.avsluttsaksombortfalt.put);
-router.post('/fagsaker/:saksnummer/henlegg-videresend', Fagsaker.fagsak.henleggVideresend.send);
+router.put('/fagsaker/:saksnummer/henlegg-videresend', Fagsaker.fagsak.henleggVideresend.put);
 
 router.get('/fagsaker/:saksnummer/aktoerer', Fagsaker.aktoer.hent);
 router.post('/fagsaker/:saksnummer/aktoerer', Fagsaker.aktoer.send);

--- a/scripts/modules/fagsaker/fagsaker.js
+++ b/scripts/modules/fagsaker/fagsaker.js
@@ -33,5 +33,5 @@ module.exports.henleggVideresend = (req, res) => {
 
   if (!saksnummer) return Mock.manglerParamSaksnummer(req, res);
   const { moduleName } = Katalog.pathnameMap['fagsaker-henleggvideresend'];
-  SchemaValidator.post204(moduleName,req, res);
+  SchemaValidator.put204(moduleName,req, res);
 };

--- a/scripts/modules/fagsaker/index.js
+++ b/scripts/modules/fagsaker/index.js
@@ -5,7 +5,7 @@ const { sokFagsak }  = require('./sok');
 const { hentKontaktopplysninger, sendKontaktopplysninger, slettKontaktopplysninger } = require('./kontaktopplysninger');
 
 module.exports = {
-  fagsak: { hent: hentFagsak, henlegg: { send: henleggFagsak}, avsluttsaksombortfalt: {put: avsluttsaksombortfalt}, henleggVideresend: { send: henleggVideresend } },
+  fagsak: { hent: hentFagsak, henlegg: { send: henleggFagsak}, avsluttsaksombortfalt: {put: avsluttsaksombortfalt}, henleggVideresend: { put: henleggVideresend } },
   aktoer: { hent: hentAktoerer, send: sendAktoer, slett: slettAktoer },
   sok: { hent: sokFagsak },
   kontaktopplysninger: {


### PR DESCRIPTION
Skal ikke sende fritekst ved videresending av søknad.
Bruker ny schema versjon etter revert. PR: https://github.com/navikt/melosys-schema/pull/110
___
Revert "Merge pull request #279 from navikt/MELOSYS-3266_videresend_fritekst"

This reverts commit a5a2833, reversing
changes made to 4b10c87.