### PR TITLE
Hent melosys schema fra github packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+registry=https://npm.pkg.github.com/navikt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,25 +6,30 @@ To request typer er støttet
 * [GET] mock data filer fra `mock_data` katalogen
 * [POST] tar imot req.body og kjører schema validering på body
 
+## Autentisering til github packages
+Github packages krever en token ved npm install. Den kan settes slik:
+https://help.github.com/en/github/managing-packages-with-github-packages/configuring-npm-for-use-with-github-packages#authenticating-to-github-packages
+
 ## Mock data, Schema og validering
 Mock data valideres vha JSON Schema.
 * `npm run schema`
 
 Schema skriptet enumerer alle importerte schema, kartlegger alle kataloger i mock_data.
-Itererer og validerer alle mock data filer hver katalog med assosiert schema. 
+Itererer og validerer alle mock data filer hver katalog med assosiert schema.
 
 ## Testing av [POST] body data
 * Start mock serveren `npm run happycase`
 * Åpnet nytt shell og kjør `npm run post`
 
 Skriptet post, enumerer alle endepunkter med [POST] actions, og leser post mock data, og sender dem til mock serveren og rapporterer success eller failed schema validering.
+
 # Hvordan bidra
 
-I Melosys-prosjektet brukes JSON-schema til å definere kontrakten mellom frontend og backend. Det er derfor viktig å ha et sett med konvensjoner for å opprettholde høy kvalitet og gjøre det enklere å forvalte mock og schema. 
+I Melosys-prosjektet brukes JSON-schema til å definere kontrakten mellom frontend og backend. Det er derfor viktig å ha et sett med konvensjoner for å opprettholde høy kvalitet og gjøre det enklere å forvalte mock og schema.
 
 ### Mock-data
 
-Alle mock-data skal valideres mot JSON-schema. For å oppnå dette, må vi så langt det lar seg gjøre unngå hardkoding av filnavn, slik at det er mulig å dynamisk levere og validere filer per endpoint. 
+Alle mock-data skal valideres mot JSON-schema. For å oppnå dette, må vi så langt det lar seg gjøre unngå hardkoding av filnavn, slik at det er mulig å dynamisk levere og validere filer per endpoint.
 
 ### JSON-schema
 

--- a/mock.config.js
+++ b/mock.config.js
@@ -1,6 +1,6 @@
 const { getInstalledPathSync } = require('get-installed-path');
 
-const SCRIPTS_DIR = getInstalledPathSync('melosys-schema', { local: true });
+const SCRIPTS_DIR = getInstalledPathSync('@navikt/melosys-schema', { local: true });
 
 const MOCK_DATA_DIR = `${SCRIPTS_DIR}/mock_data`;
 const SCHEMA_DIR = `${SCRIPTS_DIR}/schema`;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.15",
     "log4js": "^5.1.0",
     "melosys-kodeverk": "^5.12.1",
-    "melosys-schema": "^1.34.0",
+    "@navikt/melosys-schema": "^1.35.0",
     "moment": "^2.24.0",
     "node-cache": "^4.2.1",
     "node-emoji": "^1.10.0",


### PR DESCRIPTION
Det må settes en token for å hente fra github packages. Den kan settes slik: https://help.github.com/en/github/managing-packages-with-github-packages/configuring-npm-for-use-with-github-packages#authenticating-to-github-packages