### PR TITLE
MELOSYS-4009 - 404 for get

### DIFF
--- a/scripts/utils/schemavalidator/schema-get-validator.js
+++ b/scripts/utils/schemavalidator/schema-get-validator.js
@@ -15,7 +15,7 @@ module.exports.get = async (moduleName, req, res, pathObject = {}) => {
     return res.json(data);
   }
   catch(err) {
-    Mock.serverError(req, res, err);
+    Mock.notFound(req, res, err);
   }
 };
 


### PR DESCRIPTION
- Returner 404 i stedet for 500 når get-operasjoner ikke finner en fil. (inspirert av at backend nå skal returnere 404 for ikke-eksisterende organisasjon)